### PR TITLE
feat: Add ngram tokenizer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "Ruby",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/ruby:0-3.1-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {
+			"ppa": true,
+			"version": "os-provided"
+		},
+		"ghcr.io/devcontainers/features/ruby:1": {
+			"version": "latest"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "ruby --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,24 +8,24 @@
 		"ghcr.io/devcontainers/features/git:1": {
 			"ppa": true,
 			"version": "os-provided"
-		},
-		"ghcr.io/devcontainers/features/ruby:1": {
-			"version": "latest"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// Add the IDs of extensions you want installed when the container is created.
+				"rebornix.Ruby"
+			]
 		}
 	}
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "ruby --version",
-
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     mini_search (1.0.4)
+      ruby_ngrams (~> 0.0.6)
 
 GEM
   remote: https://rubygems.org/
@@ -21,6 +22,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    ruby_cli (0.2.1)
+    ruby_ngrams (0.0.6)
+      ruby_cli (>= 0.2.0)
 
 PLATFORMS
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,30 +6,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     rake (12.3.3)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.4.10)
   mini_search!
   rake (~> 12.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.4.10

--- a/README.md
+++ b/README.md
@@ -262,6 +262,29 @@ Arguments:
   - The stemmer is a object of type Stemmer, that implements a `stem` method that remove all but the stem of the word (example: `carrocha` -> `carr`).
   - The synonyms_map is a hashmap with original terms and a list of synonyms (example: `{'calçado' => ['sapato', 'tenis', 'salto', 'chinelo]}`)
 
+## n-gram Tokenizer
+
+By default creating an index using `MiniSearch.new_index` will gives an inverted_index that uses a simple whitespace tokenizer.
+(e.g. `"Hello World" => ["Hello", "World"]`)
+
+You can change this behavior to use an n-gram tokenizer which will break words down into smaller pieces with a configurable
+token window. You can read more about how this kind of tokenization works for [Elastic Search](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html).
+(e.g. `ngrams: 2` the phrase `"Hello World" => ["He", "el", "ll", "lo", "o ", " W", "Wo", "or", "rl", "ld"]`)
+or
+(e.g. `ngrams: 3` the phrase `"Hello World" => ["Hel", "ell", "llo", "lo ", "o W", " Wo", "Wor", "orl", "rld"]`)
+
+To enable this simply pass an integer for the parameter `ngrams`.
+
+```
+index = MiniSearch.new_index(
+  ngrams: 2,
+)
+```
+
+Arguments:
+
+- ngrams: An integer which represents the amount of characters each token should be. Common paramaeters are: (`2` for bigrams or `3` for trigrams)
+
 # Stemmers
 
 Stemmers are classes that implements the `def stem(word)` method, that receives a word and returs the stem:

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 
 require "bundler/setup"
 require "mini_search"
+require "ruby_ngrams" # We want to be able to use this when testing!
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/mini_search/ngram_tokenizer.rb
+++ b/lib/mini_search/ngram_tokenizer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "ruby_ngrams"
+
+module MiniSearch
+  class NgramTokenizer
+    def initialize(n)
+      n ||= 2
+      @n = n
+    end
+    def execute(string)
+      string.ngrams(regex: //, n: @n).map(&:join)
+    end
+  end
+end

--- a/lib/mini_search/ngram_tokenizer.rb
+++ b/lib/mini_search/ngram_tokenizer.rb
@@ -8,6 +8,8 @@ module MiniSearch
       @n = n
     end
     def execute(string)
+      # In the future, we may want to consider doing a strip on tokens to remove
+      # whitespace.
       string.ngrams(regex: //, n: @n).map(&:join)
     end
   end

--- a/lib/mini_search/pipeline.rb
+++ b/lib/mini_search/pipeline.rb
@@ -5,16 +5,27 @@ module MiniSearch
   # do when indexing a document or searching
   class Pipeline
     def initialize(tokenizer, filters)
+      @standard_tokenizer = MiniSearch::StandardWhitespaceTokenizer.new
       @tokenizer = tokenizer
       @filters = filters
     end
 
     def execute(string)
-      tokens = @tokenizer.execute(string)
+      # Since the filter model expects tokens that are tokenized by
+      # the standard tokenizer, let's use that first.
+      tokens = @standard_tokenizer.execute(string)
 
-      @filters.reduce(tokens) do |filtered_tokens, filter|
+      # Apply filters
+      filters_applied = @filters.reduce(tokens) do |filtered_tokens, filter|
         filter.execute(filtered_tokens)
       end
+
+      # Return if our selected tokenizer is the standard tokenizer
+      return filters_applied if @tokenizer.is_a? MiniSearch::StandardWhitespaceTokenizer
+
+      # Execute non-standard tokenization after rejoining the tokens
+      # that were tokenized with the StandardWhitespaceTokenizer
+      @tokenizer.execute(filters_applied.join(' '))
     end
   end
 end

--- a/lib/mini_search/version.rb
+++ b/lib/mini_search/version.rb
@@ -1,3 +1,3 @@
 module MiniSearch
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/mini_search.gemspec
+++ b/mini_search.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.4.10"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_runtime_dependency "ruby_ngrams", "~> 0.0.6"
 end

--- a/mini_search.gemspec
+++ b/mini_search.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.4.10"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/mini_search/inverted_index_spec.rb
+++ b/spec/mini_search/inverted_index_spec.rb
@@ -174,27 +174,24 @@ RSpec.describe MiniSearch::InvertedIndex do
       expect(subject.search('red cat')).to eq(
         documents: [
           # 10 - matches both red and cat so it is the first
-          { document: { id: 10, indexed_field: 'red big cat' }, score: 5.2417439118759885 },
+          { document: { id: 10, indexed_field: 'red big cat' }, score: 5.679142860867156 },
 
           # 3 - matches cat so it is the second as cat has a bigger IDF (it is more uncommon)
           { document: { id: 3, indexed_field: 'small cat' }, score: 3.87904607207589 },
 
-          { document: { id: 4, indexed_field: 'red monkey noisy' }, score: 1.1405919495816859 },
-          { document: { id: 7, indexed_field: 'tiny red spider' }, score: 1.0860322829565763 },
-          { document: { id: 1, indexed_field: 'red duck' }, score: 0.7321317426855942 },
-
-          # Pulls in an extra document because of ngramming ("d" in dog)
-          { document: { id: 2, indexed_field: 'yellow big dog' }, score: 0.0 },
+          { document: { id: 4, indexed_field: 'red monkey noisy' }, score: 1.7108879243725288 },
+          { document: { id: 7, indexed_field: 'tiny red spider' }, score: 1.6290484244348644 },
+          { document: { id: 1, indexed_field: 'red duck' }, score: 1.0981976140283913 },
         ],
         idfs: {
+          ' c' => 1.2237754316221157,
           'at' => 1.2237754316221157,
-          'c' => 1.2237754316221157,
           'ca' => 1.2237754316221157,
-          'd' => 0.0,
+          'd ' => 0.36772478012531734,
           'ed' => 0.36772478012531734,
           're' => 0.36772478012531734
         },
-        processed_terms: ['re', 'ed', 'd', 'c', 'ca', 'at']
+        processed_terms: ['re', 'ed', 'd ', ' c', 'ca', 'at']
       )
     end
 

--- a/spec/mini_search/inverted_index_spec.rb
+++ b/spec/mini_search/inverted_index_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe MiniSearch::InvertedIndex do
   let(:stop_words) { [] }
   let(:synonyms_map) { {} }
+  let(:ngrams) { nil }
 
-  subject { MiniSearch.new_index(stop_words: stop_words, synonyms_map: synonyms_map) }
+  subject { MiniSearch.new_index(stop_words: stop_words, synonyms_map: synonyms_map, ngrams: ngrams) }
 
   it 'indexes documents and searches them' do
     subject.index(id: 1, indexed_field: 'red duck')
@@ -154,4 +155,49 @@ RSpec.describe MiniSearch::InvertedIndex do
       processed_terms: ['red', 'cat']
     )
   end
+
+  context 'using ngrams' do
+    let(:ngrams) { 2 }
+
+    it 'uses ngram tokenizer if ngrams is not nil' do
+      subject.index(id: 1, indexed_field: 'red duck')
+      subject.index(id: 2, indexed_field: 'yellow big dog')
+      subject.index(id: 3, indexed_field: 'small cat')
+      subject.index(id: 4, indexed_field: 'red monkey noisy')
+      subject.index(id: 5, indexed_field: 'small horse')
+      subject.index(id: 6, indexed_field: 'purple turtle')
+      subject.index(id: 7, indexed_field: 'tiny red spider')
+      subject.index(id: 8, indexed_field: 'big blue whale')
+      subject.index(id: 9, indexed_field: 'huge elephant')
+      subject.index(id: 10, indexed_field: 'red big cat')
+
+      expect(subject.search('red cat')).to eq(
+        documents: [
+          # 10 - matches both red and cat so it is the first
+          { document: { id: 10, indexed_field: 'red big cat' }, score: 5.2417439118759885 },
+
+          # 3 - matches cat so it is the second as cat has a bigger IDF (it is more uncommon)
+          { document: { id: 3, indexed_field: 'small cat' }, score: 3.87904607207589 },
+
+          { document: { id: 4, indexed_field: 'red monkey noisy' }, score: 1.1405919495816859 },
+          { document: { id: 7, indexed_field: 'tiny red spider' }, score: 1.0860322829565763 },
+          { document: { id: 1, indexed_field: 'red duck' }, score: 0.7321317426855942 },
+
+          # Pulls in an extra document because of ngramming ("d" in dog)
+          { document: { id: 2, indexed_field: 'yellow big dog' }, score: 0.0 },
+        ],
+        idfs: {
+          'at' => 1.2237754316221157,
+          'c' => 1.2237754316221157,
+          'ca' => 1.2237754316221157,
+          'd' => 0.0,
+          'ed' => 0.36772478012531734,
+          're' => 0.36772478012531734
+        },
+        processed_terms: ['re', 'ed', 'd', 'c', 'ca', 'at']
+      )
+    end
+
+  end
+
 end

--- a/spec/mini_search/ngram_tokenizer_spec.rb
+++ b/spec/mini_search/ngram_tokenizer_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe MiniSearch::NgramTokenizer do
+
+    let(:window) { nil }
+
+    subject { MiniSearch::NgramTokenizer.new(window) }
+
+    it 'defaults to bigrams if n is not provided' do
+        expect(subject.execute('Hello')).to eq(
+            [
+                'He',
+                'el',
+                'll',
+                'lo'
+            ]
+        )
+    end
+
+    context 'bigrams' do
+        let(:window) { 2 }
+
+        it 'produces bigrams if n is 2' do
+            expect(subject.execute('Hello')).to eq(
+                [
+                    'He',
+                    'el',
+                    'll',
+                    'lo'
+                ]
+            )
+            expect(subject.execute('Hello World!')).to eq(
+                [
+                    'He',
+                    'el',
+                    'll',
+                    'lo',
+                    'o ',
+                    ' W',
+                    'Wo',
+                    'or',
+                    'rl',
+                    'ld',
+                    'd!'
+                ]
+            )
+        end
+    end
+
+
+    context 'trigrams' do
+        let(:window) { 3 }
+
+        it 'produces bigrams if n is 3' do
+            expect(subject.execute('Hello')).to eq(
+                [
+                    'Hel',
+                    'ell',
+                    'llo'
+                ]
+            )
+            expect(subject.execute('Hello World!')).to eq(
+                [
+                    'Hel',
+                    'ell',
+                    'llo',
+                    'lo ',
+                    'o W',
+                    ' Wo',
+                    'Wor',
+                    'orl',
+                    'rld',
+                    'ld!'
+                ]
+            )
+        end
+    end
+
+end


### PR DESCRIPTION
Adds an N-gram tokenizer which can be optionally used instead of the "StandardWhitespaceTokenizer" by providing an integer to the new ngrams parameter on index creation. 

This is inspired and works similarly to the N-gram tokenizer provided by ElasticSearch: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html

Right now, it uses the [ruby_ngrams](https://github.com/martinvelez/ruby_ngrams) library, in the spirit of not re-inventing the wheel. However, this behavior could be easily replicated if we are wary about including a new runtime dependency.

This PR includes some additional changes such as:
- Bumped the bundler version and regenerated the lock file.
- (Optional) VS Code devcontainer configuration.